### PR TITLE
Fix reading threshold as float from file

### DIFF
--- a/sentence-join/sentence-join.py
+++ b/sentence-join/sentence-join.py
@@ -245,7 +245,7 @@ if args.apply:
     threshold = args.threshold
   elif os.path.exists(args.model + ".threshold"):
     fh = open(args.model + ".threshold", "r")
-    threshold = fh.readlines()[0].rstrip().split(" ")[1]
+    threshold = float(fh.readlines()[0].rstrip().split(" ")[1])
   runtime_scoring()
 
 # if no action is specified, complain


### PR DESCRIPTION
`threshold` was previously being read as a string instead of a float, which was breaking sentence-join when the threshold is read from a file, like in PDFExtract.java